### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See also https://gher-ulg.github.io/DIVAnd-presentation/#1
 
 Please cite this paper as follows if you use `DIVAnd` in a publication:
 
-Barth, A., Beckers, J.-M., Troupin, C., Alvera-Azcárate, A., and Vandenbulcke, L.: DIVAnd-1.0: n-dimensional variational data analysis for ocean observations, Geosci. Model Dev., 7, 225-241, doi:[10.5194/gmd-7-225-2014](http://dx.doi.org/10.5194/gmd-7-225-2014), 2014.
+Barth, A., Beckers, J.-M., Troupin, C., Alvera-Azcárate, A., and Vandenbulcke, L.: DIVAnd-1.0: n-dimensional variational data analysis for ocean observations, Geosci. Model Dev., 7, 225-241, doi:[10.5194/gmd-7-225-2014](https://doi.org/10.5194/gmd-7-225-2014), 2014.
 
 (click [here](./data/DIVAnd.bib) for the BibTeX entry).
 

--- a/src/SDNMetadata.jl
+++ b/src/SDNMetadata.jl
@@ -806,7 +806,7 @@ function gettemplatevars(
     end
 
     DOI_URL = if doi != ""
-        "https://dx.doi.org/" * doi
+        "https://doi.org/" * doi
     else
         "na"
     end

--- a/templates/sextant_final_example_original.xml
+++ b/templates/sextant_final_example_original.xml
@@ -510,7 +510,7 @@
           <gmd:onLine>
             <gmd:CI_OnlineResource>
               <gmd:linkage>
-                <gmd:URL>http://dx.doi.org/10.6092/f836dafd-a367-4c6e-997c-d8a53461c86f</gmd:URL>
+                <gmd:URL>https://doi.org/10.6092/f836dafd-a367-4c6e-997c-d8a53461c86f</gmd:URL>
               </gmd:linkage>
               <gmd:protocol>
                 <gco:CharacterString>WWW:DOWNLOAD-1.0-link--download</gco:CharacterString>


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly, plus the code that generates new DOI links.

Cheers!