### PR TITLE
Direct Download (NetCDF)

### DIFF
--- a/templates/emodnet-chemistry.mustache
+++ b/templates/emodnet-chemistry.mustache
@@ -722,7 +722,7 @@
                 <gco:CharacterString>Direct Download (NetCDF)</gco:CharacterString>
               </gmd:name>
               <gmd:description>
-                <gco:CharacterString>{{ NetCDF_description }}</gco:CharacterString>
+                <gco:CharacterString>Direct Download (NetCDF)</gco:CharacterString>
               </gmd:description>
             </gmd:CI_OnlineResource>
           </gmd:onLine>


### PR DESCRIPTION
Since the product is a ZIP file, the old text for a specific NetCF is irrelevant. I see this confusion in our records in EMODnet Central. Let's simply remove the description variable and copy the name.